### PR TITLE
Prevent warning about 'dead code'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 #[macro_export]
 macro_rules! static_assert {
     (let $e:expr; ) => (
-        type ArrayForStaticAssert_ = [i8; 0 - ((false == ($e)) as usize)];
+        type _ArrayForStaticAssert = [i8; 0 - ((false == ($e)) as usize)];
     );
 
     (let $e:expr; $e1:expr $(, $ee:expr)*) => (


### PR DESCRIPTION
The leading underscore is an implicit `#[allow(dead_code)]`.