### PR TITLE
Elide comparison with false

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 #[macro_export]
 macro_rules! static_assert {
     (let $e:expr; ) => (
-        type _ArrayForStaticAssert = [i8; 0 - ((false == ($e)) as usize)];
+        type _ArrayForStaticAssert = [i8; ($e) as usize - 1];
     );
 
     (let $e:expr; $e1:expr $(, $ee:expr)*) => (


### PR DESCRIPTION
Detected while running [clippy](https://github.com/Manishearth/rust-clippy/wiki#bool_comparison) on code that uses it.

Note that the code is not "clippy-clean" now, but that's a [known bug in clippy](https://github.com/Manishearth/rust-clippy/issues/1666).